### PR TITLE
feat: Complete order deletion and cart variations fixes

### DIFF
--- a/src/models/suitebiteModel.js
+++ b/src/models/suitebiteModel.js
@@ -797,7 +797,12 @@ export const Suitebite = {
   // ========== ORDER OPERATIONS ==========
 
   createOrder: async (user_id, total_points, cartItems) => {
-    console.log('Creating order with items:', cartItems);
+    console.log('🛍️ Creating order with items:', cartItems.length);
+    console.log('📦 Cart items details:', cartItems.map(item => ({
+      product_id: item.product_id,
+      variations: item.variations,
+      variation_count: item.variations ? item.variations.length : 0
+    })));
     
     // Create order
     const [orderId] = await ordersTable().insert({

--- a/src/routes/suitebiteRoutes.js
+++ b/src/routes/suitebiteRoutes.js
@@ -65,6 +65,7 @@ import {
   approveOrder,
   completeOrder,
   deleteOrder,
+  deleteOwnOrder,
   
   // Leaderboard endpoints
   getLeaderboard,
@@ -182,6 +183,7 @@ router.post("/orders/checkout", verifyToken, checkout);
 router.get("/orders/history", verifyToken, getOrderHistory);
 router.get("/orders/:id", verifyToken, getOrderById);
 router.put("/orders/:order_id/cancel", verifyToken, cancelOrder);
+router.delete("/orders/:order_id", verifyToken, deleteOwnOrder);
 router.get("/admin/orders", verifyToken, verifyAdmin, getAllOrders);
 router.put("/admin/orders/:order_id/status", verifyToken, verifyAdmin, updateOrderStatus);
 router.put("/admin/orders/:order_id/approve", verifyToken, verifyAdmin, approveOrder);

--- a/src/scripts/create_cart_item_variations_table.sql
+++ b/src/scripts/create_cart_item_variations_table.sql
@@ -1,0 +1,26 @@
+-- ============================================================================
+-- CREATE CART ITEM VARIATIONS TABLE MIGRATION
+-- ============================================================================
+-- Date: 2025-01-27
+-- Description: Add missing sl_cart_item_variations table for cart item variations
+-- ============================================================================
+
+-- Create the cart item variations table
+CREATE TABLE IF NOT EXISTS `sl_cart_item_variations` (
+  `cart_item_variation_id` int NOT NULL AUTO_INCREMENT,
+  `cart_item_id` int NOT NULL,
+  `variation_type_id` int NOT NULL,
+  `option_id` int NOT NULL,
+  `created_at` timestamp DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`cart_item_variation_id`),
+  KEY `idx_cart_item_variations_item` (`cart_item_id`),
+  KEY `idx_cart_item_variations_type` (`variation_type_id`),
+  KEY `idx_cart_item_variations_option` (`option_id`),
+  CONSTRAINT `fk_cart_item_variations_item` FOREIGN KEY (`cart_item_id`) REFERENCES `sl_cart_items` (`cart_item_id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_cart_item_variations_type` FOREIGN KEY (`variation_type_id`) REFERENCES `sl_variation_types` (`variation_type_id`) ON DELETE RESTRICT,
+  CONSTRAINT `fk_cart_item_variations_option` FOREIGN KEY (`option_id`) REFERENCES `sl_variation_options` (`option_id`) ON DELETE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Add indexes for better performance
+CREATE INDEX `idx_cart_item_variations_item_type` ON `sl_cart_item_variations` (`cart_item_id`, `variation_type_id`);
+CREATE INDEX `idx_cart_item_variations_created_at` ON `sl_cart_item_variations` (`created_at`); 

--- a/src/scripts/run_cart_variations_migration.js
+++ b/src/scripts/run_cart_variations_migration.js
@@ -1,0 +1,41 @@
+import { db } from '../config/db.js';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+async function runCartVariationsMigration() {
+  try {
+    console.log('🔧 Running cart item variations migration...');
+    
+    // Read the migration file
+    const migrationPath = path.join(__dirname, 'create_cart_item_variations_table.sql');
+    const migrationSQL = fs.readFileSync(migrationPath, 'utf8');
+    
+    // Split by semicolon to handle multiple statements
+    const statements = migrationSQL
+      .split(';')
+      .map(stmt => stmt.trim())
+      .filter(stmt => stmt && !stmt.startsWith('--'));
+    
+    // Execute each statement
+    for (const statement of statements) {
+      if (statement.toLowerCase().includes('create table') || statement.toLowerCase().includes('create index')) {
+        console.log('📋 Executing:', statement.substring(0, 50) + '...');
+        await db.raw(statement);
+      }
+    }
+    
+    console.log('✅ Cart item variations migration completed successfully!');
+    console.log('📝 Created table: sl_cart_item_variations');
+    
+  } catch (error) {
+    console.error('❌ Migration failed:', error);
+  } finally {
+    await db.destroy();
+  }
+}
+
+runCartVariationsMigration(); 

--- a/suitelifer_complete_schema.sql
+++ b/suitelifer_complete_schema.sql
@@ -368,6 +368,24 @@ CREATE TABLE `sl_cart_items` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ============================================================================
+-- CART ITEM VARIATIONS TABLE
+-- ============================================================================
+CREATE TABLE `sl_cart_item_variations` (
+  `cart_item_variation_id` int NOT NULL AUTO_INCREMENT,
+  `cart_item_id` int NOT NULL,
+  `variation_type_id` int NOT NULL,
+  `option_id` int NOT NULL,
+  `created_at` timestamp DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`cart_item_variation_id`),
+  KEY `idx_cart_item_variations_item` (`cart_item_id`),
+  KEY `idx_cart_item_variations_type` (`variation_type_id`),
+  KEY `idx_cart_item_variations_option` (`option_id`),
+  CONSTRAINT `fk_cart_item_variations_item` FOREIGN KEY (`cart_item_id`) REFERENCES `sl_cart_items` (`cart_item_id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_cart_item_variations_type` FOREIGN KEY (`variation_type_id`) REFERENCES `sl_variation_types` (`variation_type_id`) ON DELETE RESTRICT,
+  CONSTRAINT `fk_cart_item_variations_option` FOREIGN KEY (`option_id`) REFERENCES `sl_variation_options` (`option_id`) ON DELETE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ============================================================================
 -- ORDERS TABLE
 -- ============================================================================
 CREATE TABLE `sl_orders` (


### PR DESCRIPTION
- Add user order deletion functionality with deleteOwnOrder controller
- Add user order deletion route /orders/:order_id
- Update frontend API to route user/admin delete requests correctly
- Fix cart variations not being passed to order history
- Add missing sl_cart_item_variations table to database schema
- Create migration scripts for cart item variations table
- Fix add to cart balance validation - users can now add items regardless of balance
- Fix Buy Now quantity preservation in product modal
- Add balance validation for Buy Now button in product cards
- Add modal system to ShopTabContent for consistent UX
- Ensure hard delete functionality works for both user and admin panels
- Maintain data integrity and consistency across all order operations